### PR TITLE
Allow EzidPublisher function to skip contributors with a missing name

### DIFF
--- a/lambdas/utilities/ezid_publisher/app.rb
+++ b/lambdas/utilities/ezid_publisher/app.rb
@@ -194,6 +194,8 @@ module Functions
           { json: facility, type: 'Sponsor' }
         end
         contributors = contributors.flatten.compact.uniq
+        # Remove any contributors that have no name defined. The DataCite schema requires a name
+        contributors = contributors.reject { |contrib| contrib['name'].nil? || contrib['name'].blank?  }
 
         fundings = dmp.fetch('project', []).first&.fetch('funding', [])
         fundings = fundings.map do |fund|

--- a/scripts/republish_to_ezid.rb
+++ b/scripts/republish_to_ezid.rb
@@ -1,0 +1,58 @@
+require 'aws-sdk-cloudformation'
+require 'aws-sdk-eventbridge'
+
+def fetch_cf_stack_exports
+  cf_client = Aws::CloudFormation::Client.new(region: 'us-west-2')
+  @exports = cf_client.list_exports.exports
+  @exports.flatten
+end
+
+# Search the stack outputs for the name
+def fetch_eventbus_arn
+  vals = @exports.select do |exp|
+    exp.exporting_stack_id.include?("uc3-dmp-hub-#{@env}") &&
+      "#{@env}-eventbusarn" == exp.name.downcase.strip
+  end
+  vals.first[:value]
+end
+
+if ARGV.length >= 2
+  fetch_cf_stack_exports
+  @env = ARGV[0]
+  dmp_id = ARGV[1]
+  bus_arn = fetch_eventbus_arn
+  client = Aws::EventBridge::Client.new(region: ENV.fetch('AWS_REGION', 'us-west-2'))
+
+  if bus_arn
+    message = {
+      entries: [{
+        time: Time.now.utc.iso8601,
+        source: "dmphub.uc3#{@env}.cdlib.net:lambda:event_publisher",
+        detail_type: "EZID update",
+        detail: {
+          PK: "DMP#doi.org/#{dmp_id}",
+          SK: "VERSION#latest",
+          dmphub_provenance_id: "PROVENANCE#dmptool"
+        }.to_json,
+        event_bus_name: bus_arn
+      }]
+    }
+
+    puts "Sending a message to the EventBus to kick off the EzidPublisher function"
+    pp message
+
+    resp = client.put_events(message)
+
+    if resp.failed_entry_count.nil? || resp.failed_entry_count.positive?
+      puts "Unable to publish message to the EventBus!"
+      pp resp
+    else
+      puts "Done. Kicked off the EzidPublisher Lambda Function."
+    end
+  else
+    puts "Unable to find EventBus for #{@env}"
+  end
+else
+  puts "Expected 2 arguments: the environment and the DOI (without the protocol and domain!"
+  puts "    e.g. ruby republish_to_ezid.rb dev 10.99999/A1B2C3D4"
+end

--- a/scripts/republish_to_ezid.rb
+++ b/scripts/republish_to_ezid.rb
@@ -1,6 +1,13 @@
 require 'aws-sdk-cloudformation'
 require 'aws-sdk-eventbridge'
 
+# Republish To EZID
+# ---------------------------------------------------------------------------------------
+# Use this scipt to manually trigger the EzidPublisher function for the specified DMP ID
+#
+# Note that the DMP ID should be specified in the [shoulder][id] format (e.g. 11.9999/A1B2C3)
+# ---------------------------------------------------------------------------------------
+
 def fetch_cf_stack_exports
   cf_client = Aws::CloudFormation::Client.new(region: 'us-west-2')
   @exports = cf_client.list_exports.exports


### PR DESCRIPTION
Fixes #7 

- Updated the EzidPublisher function so that it skips contributors with empty names
- Also added a script to manually republish the latest version of a DMP ID to EZID. 