### PR TITLE
Initial DuckDB Index Table SQL queries

### DIFF
--- a/queries/data-transformations/README.md
+++ b/queries/data-transformations/README.md
@@ -15,12 +15,12 @@ python3 ./data_transformations/crossref_transform.py "/path/to/March 2025 Public
 
 OpenAlex Works (these are large files, so it is faster to use smaller batches):
 ```bash
-python3 ./data_transformations/openalex_transform.py /path/to/openalex-snapshot /path/to/transformed/openalex works --max-file-processes=4 --batch-size=4
+python3 ./data_transformations/openalex_transform.py /path/to/openalex-snapshot /path/to/transformed/openalex_works works --max-file-processes=4 --batch-size=4
 ```
 
 OpenAlex Funders:
 ```bash
-python3 ./data_transformations/openalex_transform.py /path/to/openalex-snapshot /path/to/transformed/openalex funders
+python3 ./data_transformations/openalex_transform.py /path/to/openalex-snapshot /path/to/transformed/openalex_funders funders
 ```
 
 DataCite:

--- a/queries/data-transformations/data_transformations/ror_transform.py
+++ b/queries/data-transformations/data_transformations/ror_transform.py
@@ -31,10 +31,11 @@ def create_ror_index(ror_df: pl.DataFrame) -> pl.DataFrame:
         .select(
             pl.col("ror_id"),
             type=pl.col("type"),
-            identifier=pl.when(pl.col("type") == "isni")
+            identifier=pl.when(pl.col("type") == "isni")  # Clean ISNIs
             .then(normalise_isni(pl.col("identifier")))
+            .when(pl.col("type") == "fundref")  # Add 10.13039 prefix to Fundref IDs
+            .then(pl.concat_str([pl.lit("10.13039/"), pl.col("identifier").str.strip_chars().str.to_lowercase()]))
             .otherwise(pl.col("identifier").str.strip_chars().str.to_lowercase()),
-            # TODO: do we need to add 10.13039 prefix to fundref IDs?
         )
     )
 

--- a/queries/sql/create-variables.sql
+++ b/queries/sql/create-variables.sql
@@ -1,0 +1,5 @@
+-- Create Variables
+SET VARIABLE DATA_PATH = '/path/to/parquets/';
+
+-- Create Macros
+CREATE OR REPLACE MACRO ARRAY_AGG_DISTINCT(col) AS COALESCE(ARRAY_AGG(DISTINCT col) FILTER (WHERE col IS NOT NULL), []);

--- a/queries/sql/create-views.sql
+++ b/queries/sql/create-views.sql
@@ -1,0 +1,45 @@
+-- Crossref: create tables and views
+CREATE OR REPLACE VIEW crossref_works AS
+SELECT * FROM read_parquet(getvariable('DATA_PATH') || 'crossref/parquets/crossref_works_[0-9]*.parquet');
+
+CREATE OR REPLACE VIEW crossref_works_funders AS
+SELECT * FROM read_parquet(getvariable('DATA_PATH') || 'crossref/parquets/crossref_works_funders_[0-9]*.parquet');
+
+CREATE OR REPLACE VIEW crossref_relations AS
+SELECT * FROM read_parquet(getvariable('DATA_PATH') || 'crossref/parquets/crossref_works_relations_[0-9]*.parquet');
+
+-- DataCite: create tables and views
+CREATE OR REPLACE VIEW datacite_works AS
+SELECT * FROM read_parquet(getvariable('DATA_PATH') || 'datacite/parquets/datacite_works_[0-9]*.parquet');
+
+CREATE OR REPLACE VIEW datacite_works_affiliations AS
+SELECT * FROM read_parquet(getvariable('DATA_PATH') || 'datacite/parquets/datacite_works_affiliations_[0-9]*.parquet');
+
+CREATE OR REPLACE VIEW datacite_works_authors AS
+SELECT * FROM read_parquet(getvariable('DATA_PATH') || 'datacite/parquets/datacite_works_authors_[0-9]*.parquet');
+
+CREATE OR REPLACE VIEW datacite_works_funders AS
+SELECT * FROM read_parquet(getvariable('DATA_PATH') || 'datacite/parquets/datacite_works_funders_[0-9]*.parquet');
+
+CREATE OR REPLACE VIEW datacite_relations AS
+SELECT * FROM read_parquet(getvariable('DATA_PATH') || 'datacite/parquets/datacite_works_relations_[0-9]*.parquet');
+
+-- OpenAlex: create tables and views
+CREATE OR REPLACE VIEW openalex_works AS
+SELECT * FROM read_parquet(getvariable('DATA_PATH') || 'openalex_works/parquets/openalex_works_[0-9]*.parquet');
+
+CREATE OR REPLACE VIEW openalex_works_affiliations AS
+SELECT * FROM read_parquet(getvariable('DATA_PATH') || 'openalex_works/parquets/openalex_works_affiliations_[0-9]*.parquet');
+
+CREATE OR REPLACE VIEW openalex_works_authors AS
+SELECT * FROM read_parquet(getvariable('DATA_PATH') || 'openalex_works/parquets/openalex_works_authors_[0-9]*.parquet');
+
+CREATE OR REPLACE VIEW openalex_works_funders AS
+SELECT * FROM read_parquet(getvariable('DATA_PATH') || 'openalex_works/parquets/openalex_works_funders_[0-9]*.parquet');
+
+CREATE OR REPLACE VIEW openalex_funders AS
+SELECT * FROM read_parquet(getvariable('DATA_PATH') || 'openalex_funders/parquets/openalex_funders_[0-9]*.parquet');
+
+-- ROR: create tables and views
+CREATE OR REPLACE VIEW ror_index AS
+SELECT * FROM read_parquet(getvariable('DATA_PATH') || 'ror/ror.parquet');

--- a/queries/sql/normalise-datacite.sql
+++ b/queries/sql/normalise-datacite.sql
@@ -1,0 +1,241 @@
+-- Normalise DataCite
+
+CREATE OR REPLACE TABLE datacite_index AS
+WITH affiliation_rors AS (
+  SELECT
+    doi,
+    ARRAY_AGG_DISTINCT(ror) AS affiliation_rors,
+  FROM (
+    -- Only use ROR IDs for affiliation IDs
+
+    -- DataCite
+    -- Convert various identifiers (ROR, GRID, ISNI) to ROR
+    SELECT doi, ror_index.identifier AS ror
+    FROM datacite_works
+    LEFT JOIN datacite_works_affiliations AS dwa ON doi = dwa.work_doi
+    LEFT JOIN ror_index ON dwa.affiliation_identifier = ror_index.identifier
+
+    UNION
+
+    -- OpenAlex
+    SELECT doi, ror
+    FROM datacite_works
+    LEFT JOIN openalex_works_affiliations ON doi = work_doi
+  )
+  GROUP BY doi
+),
+affiliation_names AS (
+  SELECT
+    doi,
+    ARRAY_AGG_DISTINCT(name) AS affiliation_names,
+  FROM (
+    -- DataCite
+    SELECT doi, name
+    FROM datacite_works
+    LEFT JOIN datacite_works_affiliations ON doi = work_doi
+
+    UNION
+
+    -- OpenAlex
+    SELECT doi, display_name AS name
+    FROM datacite_works
+    LEFT JOIN openalex_works_affiliations ON doi = work_doi
+  )
+  GROUP BY doi
+),
+author_names AS (
+  SELECT
+    doi,
+    ARRAY_AGG_DISTINCT(name) AS author_names,
+  FROM (
+    -- DataCite
+    SELECT doi, name -- TODO: given_name, family_name, name
+    FROM datacite_works
+    LEFT JOIN datacite_works_authors ON doi = work_doi
+
+    UNION
+
+    -- OpenAlex
+    SELECT doi, display_name AS name
+    FROM datacite_works
+    LEFT JOIN openalex_works_authors ON doi = work_doi
+  )
+  GROUP BY doi
+),
+author_orcids AS (
+  SELECT
+    doi,
+    ARRAY_AGG_DISTINCT(orcid) AS author_orcids,
+  FROM (
+    -- Only use ORCID IDs for author identifiers
+
+    -- DataCite
+    SELECT doi, orcid
+    FROM datacite_works
+    LEFT JOIN datacite_works_authors ON doi = work_doi
+
+    UNION
+
+    -- OpenAlex
+    SELECT doi, orcid
+    FROM datacite_works
+    LEFT JOIN openalex_works_authors ON doi = work_doi
+  )
+  GROUP BY doi
+),
+award_ids AS (
+  SELECT
+    doi,
+    ARRAY_AGG_DISTINCT(award_id) AS award_ids,
+  FROM (
+    -- DataCite
+    SELECT doi, award_number AS award_id
+    FROM datacite_works
+    LEFT JOIN datacite_works_funders ON doi = work_doi
+
+    UNION
+
+    -- OpenAlex
+    SELECT doi, award_id
+    FROM datacite_works
+    LEFT JOIN openalex_works_funders ON doi = work_doi
+  )
+  GROUP BY doi
+),
+funder_ids AS (
+  SELECT
+    doi,
+    ARRAY_AGG_DISTINCT(id) AS funder_ids,
+  FROM (
+    -- Include ROR and Crossref Funder IDs for funder identifiers
+
+    -- DataCite
+    -- Include DataCite funder Crossref Funder IDs
+    SELECT doi, dwf.funder_identifier AS id
+    FROM datacite_works
+    LEFT JOIN datacite_works_funders AS dwf ON doi = dwf.work_doi
+    WHERE dwf.funder_identifier_type = 'Crossref Funder ID'
+
+    UNION
+
+    -- Convert DataCite funder IDs to ROR IDs
+    SELECT doi, ror_index.ror_id AS id
+    FROM datacite_works
+    LEFT JOIN datacite_works_funders AS dwf ON doi = dwf.work_doi
+    LEFT JOIN ror_index ON dwf.funder_identifier = ror_index.identifier
+
+    UNION
+
+    -- OpenAlex
+    -- Get OpenAlex funder Crossref Funder IDs
+    SELECT doi, oa_fndrs.ids.doi AS id
+    FROM datacite_works
+    LEFT JOIN openalex_works_funders AS oaw_fndrs ON doi = work_doi
+    LEFT JOIN openalex_funders AS oa_fndrs ON oaw_fndrs.funder_id = oa_fndrs.id
+    WHERE oa_fndrs.ids.doi IS NOT NULL
+
+    UNION
+
+    -- Get ROR IDs
+    -- Get OpenAlex funder ROR IDs
+    SELECT doi, oa_fndrs.ids.ror AS id
+    FROM datacite_works
+    LEFT JOIN openalex_works_funders AS oaw_fndrs ON doi = work_doi
+    LEFT JOIN openalex_funders AS oa_fndrs ON oaw_fndrs.funder_id = oa_fndrs.id
+    WHERE oa_fndrs.ids.ror IS NOT NULL
+  )
+  GROUP BY doi
+),
+funder_names AS (
+  SELECT
+    doi,
+    ARRAY_AGG_DISTINCT(name) AS funder_names,
+  FROM (
+    -- DataCite
+    SELECT doi, funder_name AS name
+    FROM datacite_works
+    LEFT JOIN datacite_works_funders ON doi = work_doi
+
+    UNION
+
+    -- OpenAlex
+    SELECT doi, funder_display_name AS name
+    FROM datacite_works
+    LEFT JOIN openalex_works_funders ON doi = work_doi
+  )
+  GROUP BY doi
+),
+-- Choose the most recent updated date from DataCite and OpenAlex
+updated_dates AS (
+  SELECT
+    doi,
+    MAX(updated_date) AS updated_date
+  FROM (
+    SELECT doi, updated_date
+    FROM datacite_works
+
+    UNION
+
+    SELECT doi, updated_date
+    FROM openalex_works
+    WHERE doi IS NOT NULL
+  )
+  GROUP BY doi
+),
+type_map AS (
+  -- Mapping table to normalise DataCite types
+  SELECT * FROM (VALUES
+    ('JournalArticle', 'article'),
+    ('ConferencePaper', 'article'),
+    ('Audiovisual', 'audio-visual'),
+    ('Film', 'audio-visual'),
+    ('Book', 'book'),
+    ('BookChapter', 'book-chapter'),
+    ('Collection', 'collection'),
+    ('DataPaper', 'data-paper'),
+    ('Dataset', 'dataset'),
+    ('Dissertation', 'dissertation'),
+    ('Event', 'event'),
+    ('Image', 'image'),
+    ('InteractiveResource', 'interactive-resource'),
+    ('Model', 'model'),
+    ('OutputManagementPlan', 'output-management-plan'),
+    ('PeerReview', 'peer-review'),
+    ('PhysicalObject', 'physical-object'),
+    ('Instrument', 'physical-object'),
+    ('Preprint', 'preprint'),
+    ('Report', 'report'),
+    ('Service', 'service'),
+    ('Software', 'software'),
+    ('ComputationalNotebook', 'software'),
+    ('Sound', 'sound'),
+    ('Standard', 'standard'),
+    ('Text', 'text'),
+    ('Workflow', 'workflow'),
+    ('Other', 'other')
+  ) AS t(original_type, normalized_type)
+)
+SELECT
+  datacite_works.doi,
+  datacite_works.title,
+  datacite_works.abstract,
+  COALESCE(type_map.normalized_type, 'other') AS type,
+  datacite_works.publication_date,
+  updated_dates.updated_date,
+  affiliation_rors.affiliation_rors,
+  affiliation_names.affiliation_names,
+  author_names.author_names,
+  author_orcids.author_orcids,
+  award_ids.award_ids,
+  funder_ids.funder_ids,
+  funder_names.funder_names
+FROM datacite_works
+LEFT JOIN affiliation_rors ON datacite_works.doi = affiliation_rors.doi
+LEFT JOIN affiliation_names ON datacite_works.doi = affiliation_names.doi
+LEFT JOIN author_names ON datacite_works.doi = author_names.doi
+LEFT JOIN author_orcids ON datacite_works.doi = author_orcids.doi
+LEFT JOIN award_ids ON datacite_works.doi = award_ids.doi
+LEFT JOIN funder_ids ON datacite_works.doi = funder_ids.doi
+LEFT JOIN funder_names ON datacite_works.doi = funder_names.doi
+LEFT JOIN updated_dates ON datacite_works.doi = updated_dates.doi
+LEFT JOIN type_map ON datacite_works.type = type_map.original_type

--- a/queries/sql/normalise-openalex.sql
+++ b/queries/sql/normalise-openalex.sql
@@ -1,0 +1,151 @@
+-- Normalise OpenAlex
+
+CREATE OR REPLACE TABLE openalex_index AS
+WITH
+idx AS (
+  -- Remove DataCite works from OpenAlex
+  SELECT
+    id,
+    doi
+  FROM openalex_works
+  WHERE doi IS NOT NULL AND NOT EXISTS (SELECT 1 FROM datacite_works WHERE openalex_works.doi = datacite_works.doi)
+),
+funder_ids AS (
+  SELECT
+    doi,
+    ARRAY_AGG_DISTINCT(funder_id) AS funder_ids
+  FROM (
+    -- OpenAlex
+    -- Get OpenAlex funder Crossref Funder IDs
+    SELECT idx.id, idx.doi, oa_fndrs.ids.doi AS funder_id
+    FROM idx
+    LEFT JOIN openalex_works_funders AS oaw_fndrs ON idx.id = oaw_fndrs.work_id
+    LEFT JOIN openalex_funders AS oa_fndrs ON oaw_fndrs.funder_id = oa_fndrs.id
+    WHERE oa_fndrs.ids.doi IS NOT NULL
+
+    UNION
+
+    -- Get ROR IDs
+    -- Get OpenAlex funder ROR IDs
+    SELECT idx.id, idx.doi, oa_fndrs.ids.ror AS funder_id
+    FROM idx
+    LEFT JOIN openalex_works_funders AS oaw_fndrs ON idx.id = oaw_fndrs.work_id
+    LEFT JOIN openalex_funders AS oa_fndrs ON oaw_fndrs.funder_id = oa_fndrs.id
+    WHERE oa_fndrs.ids.ror IS NOT NULL
+
+    UNION
+
+    -- Crossref Metadata
+    SELECT idx.id, idx.doi, cfw_fndrs.funder_doi AS funder_id
+    FROM idx
+    LEFT JOIN crossref_works_funders AS cfw_fndrs ON idx.doi = cfw_fndrs.work_doi
+  )
+  GROUP BY doi
+),
+funder_names AS (
+  SELECT
+    doi,
+    ARRAY_AGG_DISTINCT(funder_name) AS funder_names
+  FROM (
+    -- OpenAlex
+    SELECT idx.id, idx.doi, oaw_fndrs.funder_display_name AS funder_name
+    FROM idx
+    LEFT JOIN openalex_works_funders AS oaw_fndrs ON idx.id = oaw_fndrs.work_id
+
+    UNION
+
+    -- Crossref Metadata
+    SELECT idx.id, idx.doi, cfw_fndrs.name AS funder_name
+    FROM idx
+    LEFT JOIN crossref_works_funders AS cfw_fndrs ON idx.doi = cfw_fndrs.work_doi
+  )
+  GROUP BY doi
+),
+award_ids AS (
+  SELECT
+    doi,
+    ARRAY_AGG_DISTINCT(award_id) AS award_ids
+  FROM (
+    -- OpenAlex
+    SELECT idx.id, idx.doi, oaw_fndrs.award_id
+    FROM idx
+    LEFT JOIN openalex_works_funders AS oaw_fndrs ON idx.id = oaw_fndrs.work_id
+
+    UNION
+
+    -- Crossref Metadata
+    SELECT idx.id, idx.doi, cfw_fndrs.award AS award_id
+    FROM idx
+    LEFT JOIN crossref_works_funders AS cfw_fndrs ON idx.doi = cfw_fndrs.work_doi
+  )
+  GROUP BY doi
+),
+updated_dates AS (
+  -- Choose most recent update_date from OpenAlex and Crossref Metadata
+  SELECT
+    doi,
+    MAX(updated_date) AS updated_date
+  FROM (
+    SELECT idx.doi, oaw.updated_date
+    FROM idx
+    LEFT JOIN openalex_works AS oaw ON idx.id = oaw.id
+
+    UNION
+
+    SELECT doi, updated_date
+    FROM crossref_works
+    WHERE doi IS NOT NULL
+  )
+  GROUP BY doi
+),
+works_merged AS (
+  -- OpenAlex contains duplicate works with the same DOI. Sometimes one work has more metadata than others, so group and merge all data together.
+  SELECT
+    doi,
+    MIN(title) AS title, -- Could change to longest
+    MIN(abstract) AS abstract, -- Could change to longest
+    MIN(type) AS type, -- Could change to most common
+    MAX(publication_date) AS publication_date,
+    ARRAY_AGG_DISTINCT(affiliation_ror) AS affiliation_rors,
+    ARRAY_AGG_DISTINCT(affiliation_name) AS affiliation_names,
+    ARRAY_AGG_DISTINCT(author_name) AS author_names,
+    ARRAY_AGG_DISTINCT(author_orcid) AS author_orcids,
+  FROM (
+    SELECT
+      idx.doi,
+      oaw.title,
+      oaw.abstract,
+      oaw.type,
+      oaw.publication_date,
+      oaw.updated_date,
+      oaw_affl.ror AS affiliation_ror,
+      oaw_affl.display_name AS affiliation_name,
+      oaw_auth.display_name AS author_name,
+      oaw_auth.orcid AS author_orcid,
+    FROM idx
+    LEFT JOIN openalex_works AS oaw ON idx.id = oaw.id
+    LEFT JOIN openalex_works_affiliations AS oaw_affl ON idx.id = oaw_affl.work_id
+    LEFT JOIN openalex_works_authors AS oaw_auth ON idx.id = oaw_auth.work_id
+  ) AS subquery
+  GROUP BY doi
+)
+SELECT
+  works.doi,
+  COALESCE(crossref_works.title, works.title) AS title,
+  COALESCE(crossref_works.abstract, works.abstract) AS abstract,
+  works.type,
+  works.publication_date,
+  updated_dates.updated_date,
+  works.affiliation_rors,
+  works.affiliation_names,
+  works.author_names,
+  works.author_orcids,
+  funder_ids.funder_ids,
+  funder_names.funder_names,
+  award_ids.award_ids
+FROM works_merged AS works
+LEFT JOIN funder_ids ON works.doi = funder_ids.doi
+LEFT JOIN funder_names ON works.doi = funder_names.doi
+LEFT JOIN award_ids ON works.doi = award_ids.doi
+LEFT JOIN updated_dates ON works.doi = updated_dates.doi
+LEFT JOIN crossref_works ON works.doi = crossref_works.doi


### PR DESCRIPTION
DuckDB SQL queries for producing the DataCite and OpenAlex index tables that will be loaded into OpenSearch for matching. 

DataCite:
* Fields are supplemented with OpenAlex metadata.
* Affiliation IDs: converted from a variety of different identifiers into ROR IDs.
* Funder IDs: selects or converts into ROR IDs and Crossref Funder IDs.
* Work type: normalises into the types we were using previously.

OpenAlex:
* DataCite works are removed, since we add OpenAlex metadata to the DataCite table and OpenAlex only has a subset of DataCite works. 
* Crossref is used to supplement titles, abstracts and funding related information.
* Funder IDs: converts from OpenAlex funder IDs to Crossref Funder IDs and ROR IDs.

Polars transformations updated:
* Fixed issues with data that became apparent after creating index table queries.
* Included updated_dates in each main dataset, which should be useful when ingesting data into Open Search.
 
For future work, will need to look at incorporating the SQL queries into a tool for managing SQL transformations, e.g. [SQLMesh](https://sqlmesh.com/) or [DBT](https://www.getdbt.com/product/what-is-dbt).