### PR TITLE
Use two stage build for AWS Docker container

### DIFF
--- a/queries/dmpworks/.dockerignore
+++ b/queries/dmpworks/.dockerignore
@@ -4,3 +4,5 @@ target
 .env
 .env.demo
 .ipynb_checkpoints
+Dockerfile
+Dockerfile.aws

--- a/queries/dmpworks/Dockerfile.aws
+++ b/queries/dmpworks/Dockerfile.aws
@@ -1,24 +1,21 @@
-FROM amazonlinux:2023
+# -----------------------------------------------------
+# Stage 1: Build Polars and dmpworks wheels using Rust
+# -----------------------------------------------------
+
+FROM amazonlinux:2023 AS builder
 
 # Build arguments
 ARG RUST_TARGET_CPU="x86-64-v3"
+ARG PYTHON_VERSION="3.12"
 ENV RUST_TARGET_CPU=${RUST_TARGET_CPU}
-ENV PIP_REQUIRE_VIRTUALENV=true
-ENV VENV_PATH=/app/polars/.venv
-ENV VENV_ACT_PATH=${VENV_PATH}/bin/activate
+ENV PYTHON_VERSION=${PYTHON_VERSION}
 
 # Install system dependencies
 RUN dnf -y install \
-    aws-cli \
-    tar \
-    zip \
-    pigz \
     wget \
-    gzip \
-    python3.12 \
-    python3.12-pip \
-    git
-
+    git \
+    python${PYTHON_VERSION} \
+    python${PYTHON_VERSION}-pip
 RUN dnf group install -y "Development Tools"
 
 # Install Rust
@@ -27,41 +24,55 @@ ENV PATH="/root/.cargo/bin:${PATH}"
 
 WORKDIR /app
 
-# Install s5cmd: https://github.com/peak/s5cmd
-RUN wget https://github.com/peak/s5cmd/releases/download/v2.3.0/s5cmd_2.3.0_Linux-64bit.tar.gz && \
-  tar -xzf s5cmd_2.3.0_Linux-64bit.tar.gz s5cmd && \
-  chmod +x s5cmd && \
-  mv s5cmd /usr/local/bin/ && \
-  rm s5cmd_2.3.0_Linux-64bit.tar.gz
-
 # Clone Polars dependencies
 RUN git clone --branch fix-load-json-as-string --single-branch https://github.com/jdddog/polars.git
 RUN git clone --branch local-build --single-branch https://github.com/jdddog/pyo3-polars.git
 
-# Setup Python virtual environment
-# TODO: would be good to get rid of the venv, but polars expects it (or creates it
-# if it doesn't exist) when building
-RUN python3.12 -m venv ${VENV_PATH}
-
-# Install Polars dependencies
-RUN rustup toolchain install nightly --component miri
+# Build Polars
 WORKDIR /app/polars/py-polars
-RUN source ${VENV_ACT_PATH} && make requirements
-RUN source ${VENV_ACT_PATH} && RUSTFLAGS="-C target-cpu=${RUST_TARGET_CPU}" make build-dist-release
+RUN python${PYTHON_VERSION} -m pip install -r requirements-dev.txt -r requirements-lint.txt
+RUN RUSTFLAGS="-C target-cpu=${RUST_TARGET_CPU}" maturin build --interpreter python${PYTHON_VERSION} --profile dist-release
 
-# Copy current dir
+# Build dmpworks
 WORKDIR /app/dmsp_api_prototype/queries/dmpworks
 COPY . .
+RUN RUSTFLAGS="-C target-cpu=${RUST_TARGET_CPU}" maturin build --interpreter python${PYTHON_VERSION} --release
 
-# Install dmpworks Python package dependencies
-RUN source ${VENV_ACT_PATH} && pip install -e .[dev]
+# ----------------------------------
+# Stage 2: Final Amazon Linux Image
+# ----------------------------------
+FROM amazonlinux:2023
 
-# Build and install the dmpworks Python package, including its Polars expression
-RUN source ${VENV_ACT_PATH} && RUSTFLAGS="-C target-cpu=${RUST_TARGET_CPU}" maturin develop --release
+# Build arguments
+ARG PYTHON_VERSION="3.12"
+ARG S5CMD_VERSION="2.3.0"
+ENV PYTHON_VERSION=${PYTHON_VERSION}
+ENV S5CMD_VERSION=${S5CMD_VERSION}
+
+# Install system dependencies
+RUN dnf -y install \
+    aws-cli \
+    tar \
+    zip \
+    wget \
+    gzip \
+    python${PYTHON_VERSION} \
+    python${PYTHON_VERSION}-pip
+RUN dnf group install -y "Development Tools"
 
 WORKDIR /app
 
-COPY entrypoint.sh /entrypoint.sh
-RUN chmod +x /entrypoint.sh
-ENTRYPOINT ["/entrypoint.sh"]
-CMD ["/bin/bash"]
+# Install s5cmd: https://github.com/peak/s5cmd
+RUN wget https://github.com/peak/s5cmd/releases/download/v${S5CMD_VERSION}/s5cmd_${S5CMD_VERSION}_Linux-64bit.tar.gz && \
+  tar -xzf s5cmd_${S5CMD_VERSION}_Linux-64bit.tar.gz s5cmd && \
+  chmod +x s5cmd && \
+  mv s5cmd /usr/local/bin/ && \
+  rm s5cmd_${S5CMD_VERSION}_Linux-64bit.tar.gz
+
+# Copy and install Polars
+COPY --from=builder /app/polars/target/wheels /app/wheels/polars
+RUN python${PYTHON_VERSION} -m pip install /app/wheels/polars/*.whl
+
+# Copy and install dmpworks
+COPY --from=builder /app/dmsp_api_prototype/queries/dmpworks/target/wheels /app/wheels/dmpworks
+RUN python${PYTHON_VERSION} -m pip install /app/wheels/dmpworks/*.whl

--- a/queries/dmpworks/entrypoint.sh
+++ b/queries/dmpworks/entrypoint.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-source ${VENV_ACT_PATH}
-exec "$@"

--- a/queries/dmpworks/pyproject.toml
+++ b/queries/dmpworks/pyproject.toml
@@ -16,7 +16,9 @@ dependencies = [
     "pyarrow>=19,<21",
     "sqlmesh>=0.188.1,<1",
     "cyclopts>=3,<4",
-    "pooch>=1,<2"
+    "pooch>=1,<2",
+    "boto3>=1,<2",
+    "orjson>=3,<4"
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Converted AWS Batch Docker image to a two-stage build (all from the same Dockerfile). The first stage installs the software needed to build Polars and dmpworks, then compiles them into Python wheels. The second stage is the image that will run in AWS Batch. It installs any required dependencies and copies the wheels built in the first stage into the image and installs them. It results in a much lighter final image, 837MB vs 3680MB in ECS.

I was also able to get rid of the Python virtual environment (not required in a Dockerfile), remove the installation of the nightly Rust toolchain, and compile the packages into Python wheels rather than build and install into the virtual environment (maturin build rather than maturin develop).