### PR TITLE
OpenSearch sync staggered start

### DIFF
--- a/queries/dmpworks/python/dmpworks/opensearch/utils.py
+++ b/queries/dmpworks/python/dmpworks/opensearch/utils.py
@@ -69,6 +69,7 @@ class OpenSearchSyncConfig:
     dry_run: bool = False
     measure_chunk_size: bool = False
     max_error_samples: int = MAX_ERROR_SAMPLES
+    staggered_start: bool = False
 
 
 def make_opensearch_client(config: OpenSearchClientConfig) -> OpenSearch:


### PR DESCRIPTION
This PR adds a staggered start feature to the OpenSearch sync, which gives OpenSearch Serverless time to spin up indexing OCUs to match demand. Each process is given `(process number -1) * 60 seconds` before indexing.