### PR TITLE
Tune SQLMesh threads

### DIFF
--- a/queries/dmpworks/python/dmpworks/sql/config.yaml
+++ b/queries/dmpworks/python/dmpworks/sql/config.yaml
@@ -10,14 +10,14 @@ gateways:
       # register_comments: True
       # pre_ping: False
       # pretty_sql: False
-      # catalogs: 
-      # extensions: 
+      # catalogs:
+      # extensions:
       connector_config:
         threads: 1
-        memory_limit: '80GB'
+        memory_limit: '200GB'
         preserve_insertion_order: 'false'
-      # secrets: 
-      # token: 
+      # secrets:
+      # token:
 
 variables:
   crossref_metadata_path: "/path/to/crossref_metadata/parquets"
@@ -29,8 +29,12 @@ variables:
   audit_crossref_metadata_works_threshold: 167008747
   audit_datacite_works_threshold: 72019576
   audit_openalex_works_threshold: 264675126
-
-
+  default_threads: 32
+  openalex_index_author_names_threads: 32
+  openalex_index_abstracts_threads: 32
+  openalex_index_titles_threads: 32
+  openalex_index_openalex_index_threads: 32
+  include_abstracts: true
 
 default_gateway: duckdb
 

--- a/queries/dmpworks/python/dmpworks/sql/models/crossref_index/works_metadata.sql
+++ b/queries/dmpworks/python/dmpworks/sql/models/crossref_index/works_metadata.sql
@@ -4,6 +4,8 @@ MODEL (
   kind FULL
 );
 
+PRAGMA threads=CAST(@VAR('default_threads') AS INT64);
+
 SELECT
   doi,
   LENGTH(title) AS title_length,

--- a/queries/dmpworks/python/dmpworks/sql/models/crossref_metadata/relations.sql
+++ b/queries/dmpworks/python/dmpworks/sql/models/crossref_metadata/relations.sql
@@ -7,5 +7,7 @@ MODEL (
   )
 );
 
+PRAGMA threads=CAST(@VAR('default_threads') AS INT64);
+
 SELECT *
 FROM read_parquet(@VAR('crossref_metadata_path') || '/crossref_works_relations_[0-9]*.parquet');

--- a/queries/dmpworks/python/dmpworks/sql/models/crossref_metadata/works.sql
+++ b/queries/dmpworks/python/dmpworks/sql/models/crossref_metadata/works.sql
@@ -18,5 +18,7 @@ MODEL (
   )
 );
 
+PRAGMA threads=CAST(@VAR('default_threads') AS INT64);
+
 SELECT *
 FROM read_parquet(@VAR('crossref_metadata_path') || '/crossref_works_[0-9]*.parquet');

--- a/queries/dmpworks/python/dmpworks/sql/models/crossref_metadata/works_affiliations.sql
+++ b/queries/dmpworks/python/dmpworks/sql/models/crossref_metadata/works_affiliations.sql
@@ -7,5 +7,7 @@ MODEL (
   )
 );
 
+PRAGMA threads=CAST(@VAR('default_threads') AS INT64);
+
 SELECT *
 FROM read_parquet(@VAR('crossref_metadata_path') || '/crossref_works_affiliations_[0-9]*.parquet');

--- a/queries/dmpworks/python/dmpworks/sql/models/crossref_metadata/works_authors.sql
+++ b/queries/dmpworks/python/dmpworks/sql/models/crossref_metadata/works_authors.sql
@@ -7,5 +7,7 @@ MODEL (
   )
 );
 
+PRAGMA threads=CAST(@VAR('default_threads') AS INT64);
+
 SELECT *
 FROM read_parquet(@VAR('crossref_metadata_path') || '/crossref_works_authors_[0-9]*.parquet');

--- a/queries/dmpworks/python/dmpworks/sql/models/crossref_metadata/works_funders.sql
+++ b/queries/dmpworks/python/dmpworks/sql/models/crossref_metadata/works_funders.sql
@@ -7,5 +7,7 @@ MODEL (
   )
 );
 
+PRAGMA threads=CAST(@VAR('default_threads') AS INT64);
+
 SELECT *
 FROM read_parquet(@VAR('crossref_metadata_path') || '/crossref_works_funders_[0-9]*.parquet');

--- a/queries/dmpworks/python/dmpworks/sql/models/datacite/relations.sql
+++ b/queries/dmpworks/python/dmpworks/sql/models/datacite/relations.sql
@@ -7,6 +7,8 @@ MODEL (
   )
 );
 
+PRAGMA threads=CAST(@VAR('default_threads') AS INT64);
+
 SELECT *
 FROM read_parquet(@VAR('datacite_path') || '/datacite_works_relations_[0-9]*.parquet');
 

--- a/queries/dmpworks/python/dmpworks/sql/models/datacite/works.sql
+++ b/queries/dmpworks/python/dmpworks/sql/models/datacite/works.sql
@@ -24,5 +24,7 @@ MODEL (
   )
 );
 
+PRAGMA threads=CAST(@VAR('default_threads') AS INT64);
+
 SELECT *
 FROM read_parquet(@VAR('datacite_path') || '/datacite_works_[0-9]*.parquet');

--- a/queries/dmpworks/python/dmpworks/sql/models/datacite/works_affiliations.sql
+++ b/queries/dmpworks/python/dmpworks/sql/models/datacite/works_affiliations.sql
@@ -8,5 +8,7 @@ MODEL (
   )
 );
 
+PRAGMA threads=CAST(@VAR('default_threads') AS INT64);
+
 SELECT *
 FROM read_parquet(@VAR('datacite_path') || '/datacite_works_affiliations_[0-9]*.parquet');

--- a/queries/dmpworks/python/dmpworks/sql/models/datacite/works_authors.sql
+++ b/queries/dmpworks/python/dmpworks/sql/models/datacite/works_authors.sql
@@ -8,5 +8,7 @@ MODEL (
   )
 );
 
+PRAGMA threads=CAST(@VAR('default_threads') AS INT64);
+
 SELECT *
 FROM read_parquet(@VAR('datacite_path') || '/datacite_works_authors_[0-9]*.parquet');

--- a/queries/dmpworks/python/dmpworks/sql/models/datacite/works_funders.sql
+++ b/queries/dmpworks/python/dmpworks/sql/models/datacite/works_funders.sql
@@ -8,5 +8,7 @@ MODEL (
   )
 );
 
+PRAGMA threads=CAST(@VAR('default_threads') AS INT64);
+
 SELECT *
 FROM read_parquet(@VAR('datacite_path') || '/datacite_works_funders_[0-9]*.parquet');

--- a/queries/dmpworks/python/dmpworks/sql/models/datacite_index/affiliation_names.sql
+++ b/queries/dmpworks/python/dmpworks/sql/models/datacite_index/affiliation_names.sql
@@ -11,6 +11,8 @@ MODEL (
   kind FULL
 );
 
+PRAGMA threads=CAST(@VAR('default_threads') AS INT64);
+
 SELECT
   doi,
   @array_agg_distinct(name) AS affiliation_names,

--- a/queries/dmpworks/python/dmpworks/sql/models/datacite_index/affiliation_rors.sql
+++ b/queries/dmpworks/python/dmpworks/sql/models/datacite_index/affiliation_rors.sql
@@ -13,6 +13,8 @@ MODEL (
   kind FULL
 );
 
+PRAGMA threads=CAST(@VAR('default_threads') AS INT64);
+
 SELECT
   doi,
   @array_agg_distinct(ror) AS affiliation_rors,

--- a/queries/dmpworks/python/dmpworks/sql/models/datacite_index/author_names.sql
+++ b/queries/dmpworks/python/dmpworks/sql/models/datacite_index/author_names.sql
@@ -11,6 +11,8 @@ MODEL (
   kind FULL
 );
 
+PRAGMA threads=CAST(@VAR('default_threads') AS INT64);
+
 SELECT
   doi,
   @array_agg_distinct(name) AS author_names,

--- a/queries/dmpworks/python/dmpworks/sql/models/datacite_index/author_orcids.sql
+++ b/queries/dmpworks/python/dmpworks/sql/models/datacite_index/author_orcids.sql
@@ -11,6 +11,8 @@ MODEL (
   kind FULL
 );
 
+PRAGMA threads=CAST(@VAR('default_threads') AS INT64);
+
 SELECT
   doi,
   @array_agg_distinct(orcid) AS author_orcids,

--- a/queries/dmpworks/python/dmpworks/sql/models/datacite_index/award_ids.sql
+++ b/queries/dmpworks/python/dmpworks/sql/models/datacite_index/award_ids.sql
@@ -11,6 +11,8 @@ MODEL (
   kind FULL
 );
 
+PRAGMA threads=CAST(@VAR('default_threads') AS INT64);
+
 SELECT
   doi,
   @array_agg_distinct(award_id) AS award_ids,

--- a/queries/dmpworks/python/dmpworks/sql/models/datacite_index/datacite_index.sql
+++ b/queries/dmpworks/python/dmpworks/sql/models/datacite_index/datacite_index.sql
@@ -11,10 +11,16 @@ MODEL (
   kind FULL
 );
 
+PRAGMA threads=CAST(@VAR('default_threads') AS INT64);
+
+JINJA_QUERY_BEGIN;
+
 SELECT
   datacite.works.doi,
   datacite.works.title,
+  {% if var('include_abstracts') %}
   datacite.works.abstract,
+  {% endif %}
   COALESCE(datacite_index.types.type, 'other') AS type,
   datacite.works.publication_date,
   datacite_index.updated_dates.updated_date,
@@ -35,3 +41,5 @@ LEFT JOIN datacite_index.author_orcids ON datacite.works.doi = datacite_index.au
 LEFT JOIN datacite_index.award_ids ON datacite.works.doi = datacite_index.award_ids.doi
 LEFT JOIN datacite_index.funder_ids ON datacite.works.doi = datacite_index.funder_ids.doi
 LEFT JOIN datacite_index.funder_names ON datacite.works.doi = datacite_index.funder_names.doi;
+
+JINJA_END;

--- a/queries/dmpworks/python/dmpworks/sql/models/datacite_index/funder_ids.sql
+++ b/queries/dmpworks/python/dmpworks/sql/models/datacite_index/funder_ids.sql
@@ -16,6 +16,8 @@ MODEL (
   kind FULL
 );
 
+PRAGMA threads=CAST(@VAR('default_threads') AS INT64);
+
 SELECT
   doi,
   @array_agg_distinct(id) AS funder_ids,

--- a/queries/dmpworks/python/dmpworks/sql/models/datacite_index/funder_names.sql
+++ b/queries/dmpworks/python/dmpworks/sql/models/datacite_index/funder_names.sql
@@ -11,6 +11,8 @@ MODEL (
   kind FULL
 );
 
+PRAGMA threads=CAST(@VAR('default_threads') AS INT64);
+
 SELECT
   doi,
   @array_agg_distinct(name) AS funder_names,

--- a/queries/dmpworks/python/dmpworks/sql/models/datacite_index/types.sql
+++ b/queries/dmpworks/python/dmpworks/sql/models/datacite_index/types.sql
@@ -11,6 +11,8 @@ MODEL (
   kind FULL
 );
 
+PRAGMA threads=CAST(@VAR('default_threads') AS INT64);
+
  -- Mapping table to normalise DataCite types
 WITH type_map AS (
   SELECT * FROM (VALUES

--- a/queries/dmpworks/python/dmpworks/sql/models/datacite_index/updated_dates.sql
+++ b/queries/dmpworks/python/dmpworks/sql/models/datacite_index/updated_dates.sql
@@ -10,6 +10,8 @@ MODEL (
   kind FULL
 );
 
+PRAGMA threads=CAST(@VAR('default_threads') AS INT64);
+
 -- Choose the most recent updated date from DataCite and OpenAlex
 SELECT
   doi,

--- a/queries/dmpworks/python/dmpworks/sql/models/openalex/funders.sql
+++ b/queries/dmpworks/python/dmpworks/sql/models/openalex/funders.sql
@@ -7,5 +7,7 @@ MODEL (
   )
 );
 
+PRAGMA threads=CAST(@VAR('default_threads') AS INT64);
+
 SELECT *
 FROM read_parquet(@VAR('openalex_funders_path') || '/openalex_funders_[0-9]*.parquet');

--- a/queries/dmpworks/python/dmpworks/sql/models/openalex/works.sql
+++ b/queries/dmpworks/python/dmpworks/sql/models/openalex/works.sql
@@ -22,5 +22,7 @@ MODEL (
   )
 );
 
+PRAGMA threads=CAST(@VAR('default_threads') AS INT64);
+
 SELECT *
 FROM read_parquet(@VAR('openalex_works_path') || '/openalex_works_[0-9]*.parquet');

--- a/queries/dmpworks/python/dmpworks/sql/models/openalex/works_affiliations.sql
+++ b/queries/dmpworks/python/dmpworks/sql/models/openalex/works_affiliations.sql
@@ -7,5 +7,7 @@ MODEL (
   )
 );
 
+PRAGMA threads=CAST(@VAR('default_threads') AS INT64);
+
 SELECT *
 FROM read_parquet(@VAR('openalex_works_path') || '/openalex_works_affiliations_[0-9]*.parquet');

--- a/queries/dmpworks/python/dmpworks/sql/models/openalex/works_authors.sql
+++ b/queries/dmpworks/python/dmpworks/sql/models/openalex/works_authors.sql
@@ -7,5 +7,7 @@ MODEL (
   )
 );
 
+PRAGMA threads=CAST(@VAR('default_threads') AS INT64);
+
 SELECT *
 FROM read_parquet(@VAR('openalex_works_path') || '/openalex_works_authors_[0-9]*.parquet');

--- a/queries/dmpworks/python/dmpworks/sql/models/openalex/works_funders.sql
+++ b/queries/dmpworks/python/dmpworks/sql/models/openalex/works_funders.sql
@@ -7,5 +7,7 @@ MODEL (
   )
 );
 
+PRAGMA threads=CAST(@VAR('default_threads') AS INT64);
+
 SELECT *
 FROM read_parquet(@VAR('openalex_works_path') || '/openalex_works_funders_[0-9]*.parquet');

--- a/queries/dmpworks/python/dmpworks/sql/models/openalex_index/abstract_stats.sql
+++ b/queries/dmpworks/python/dmpworks/sql/models/openalex_index/abstract_stats.sql
@@ -13,8 +13,11 @@
 MODEL (
   name openalex_index.abstract_stats,
   dialect duckdb,
-  kind FULL
+  kind FULL,
+  enabled @VAR('include_abstracts')
 );
+
+PRAGMA threads=CAST(@VAR('default_threads') AS INT64);
 
 -- Choose the id with the longest abstract for each duplicate DOI
 SELECT

--- a/queries/dmpworks/python/dmpworks/sql/models/openalex_index/abstracts.sql
+++ b/queries/dmpworks/python/dmpworks/sql/models/openalex_index/abstracts.sql
@@ -7,8 +7,11 @@
 MODEL (
   name openalex_index.abstracts,
   dialect duckdb,
-  kind FULL
+  kind FULL,
+  enabled @VAR('include_abstracts')
 );
+
+PRAGMA threads=CAST(@VAR('openalex_index_abstracts_threads') AS INT64);
 
 SELECT
   stats.doi,

--- a/queries/dmpworks/python/dmpworks/sql/models/openalex_index/affiliation_names.sql
+++ b/queries/dmpworks/python/dmpworks/sql/models/openalex_index/affiliation_names.sql
@@ -12,6 +12,8 @@ MODEL (
   kind FULL
 );
 
+PRAGMA threads=CAST(@VAR('default_threads') AS INT64);
+
 SELECT
   owm.doi,
   @array_agg_distinct(display_name) AS affiliation_names,

--- a/queries/dmpworks/python/dmpworks/sql/models/openalex_index/affiliation_rors.sql
+++ b/queries/dmpworks/python/dmpworks/sql/models/openalex_index/affiliation_rors.sql
@@ -12,6 +12,8 @@ MODEL (
   kind FULL
 );
 
+PRAGMA threads=CAST(@VAR('default_threads') AS INT64);
+
 SELECT
   owm.doi,
   @array_agg_distinct(ror) AS affiliation_rors,

--- a/queries/dmpworks/python/dmpworks/sql/models/openalex_index/author_names.sql
+++ b/queries/dmpworks/python/dmpworks/sql/models/openalex_index/author_names.sql
@@ -12,6 +12,8 @@ MODEL (
   kind FULL
 );
 
+PRAGMA threads=CAST(@VAR('openalex_index_author_names_threads') AS INT64);
+
 SELECT
   owm.doi,
   @array_agg_distinct(display_name) AS author_names,

--- a/queries/dmpworks/python/dmpworks/sql/models/openalex_index/author_orcids.sql
+++ b/queries/dmpworks/python/dmpworks/sql/models/openalex_index/author_orcids.sql
@@ -13,6 +13,8 @@ MODEL (
   kind FULL
 );
 
+PRAGMA threads=CAST(@VAR('default_threads') AS INT64);
+
 SELECT
   owm.doi,
   @array_agg_distinct(orcid) AS author_orcids,

--- a/queries/dmpworks/python/dmpworks/sql/models/openalex_index/award_ids.sql
+++ b/queries/dmpworks/python/dmpworks/sql/models/openalex_index/award_ids.sql
@@ -13,6 +13,8 @@ MODEL (
   kind FULL
 );
 
+PRAGMA threads=CAST(@VAR('default_threads') AS INT64);
+
 SELECT
   doi,
   @array_agg_distinct(award_id) AS award_ids

--- a/queries/dmpworks/python/dmpworks/sql/models/openalex_index/funder_ids.sql
+++ b/queries/dmpworks/python/dmpworks/sql/models/openalex_index/funder_ids.sql
@@ -15,6 +15,8 @@ MODEL (
   kind FULL
 );
 
+PRAGMA threads=CAST(@VAR('default_threads') AS INT64);
+
 SELECT
   doi,
   @array_agg_distinct(funder_id) AS funder_ids

--- a/queries/dmpworks/python/dmpworks/sql/models/openalex_index/funder_names.sql
+++ b/queries/dmpworks/python/dmpworks/sql/models/openalex_index/funder_names.sql
@@ -12,6 +12,8 @@ MODEL (
   kind FULL
 );
 
+PRAGMA threads=CAST(@VAR('default_threads') AS INT64);
+
 SELECT
   doi,
   @array_agg_distinct(funder_name) AS funder_names

--- a/queries/dmpworks/python/dmpworks/sql/models/openalex_index/openalex_index.sql
+++ b/queries/dmpworks/python/dmpworks/sql/models/openalex_index/openalex_index.sql
@@ -10,6 +10,10 @@ MODEL (
   kind FULL
 );
 
+PRAGMA threads=CAST(@VAR('openalex_index_openalex_index_threads') AS INT64);
+
+JINJA_QUERY_BEGIN;
+
 WITH dois AS (
   SELECT DISTINCT doi
   FROM openalex_index.works_metadata
@@ -18,7 +22,9 @@ WITH dois AS (
 SELECT
   dois.doi,
   openalex_index.titles.title,
+  {% if var('include_abstracts') %}
   openalex_index.abstracts.abstract,
+  {% endif %}
   COALESCE(openalex_index.types.type, 'other') AS type,
   openalex_index.publication_dates.publication_date,
   openalex_index.updated_dates.updated_date,
@@ -31,7 +37,9 @@ SELECT
   COALESCE(openalex_index.funder_names.funder_names, []) AS funder_names
 FROM dois
 LEFT JOIN openalex_index.titles ON dois.doi = openalex_index.titles.doi
+{% if var('include_abstracts') %}
 LEFT JOIN openalex_index.abstracts ON dois.doi = openalex_index.abstracts.doi
+{% endif %}
 LEFT JOIN openalex_index.types ON dois.doi = openalex_index.types.doi
 LEFT JOIN openalex_index.publication_dates ON dois.doi = openalex_index.publication_dates.doi
 LEFT JOIN openalex_index.updated_dates ON dois.doi = openalex_index.updated_dates.doi
@@ -43,3 +51,4 @@ LEFT JOIN openalex_index.award_ids ON dois.doi = openalex_index.award_ids.doi
 LEFT JOIN openalex_index.funder_ids ON dois.doi = openalex_index.funder_ids.doi
 LEFT JOIN openalex_index.funder_names ON dois.doi = openalex_index.funder_names.doi;
 
+JINJA_END;

--- a/queries/dmpworks/python/dmpworks/sql/models/openalex_index/publication_dates.sql
+++ b/queries/dmpworks/python/dmpworks/sql/models/openalex_index/publication_dates.sql
@@ -12,6 +12,8 @@ MODEL (
   kind FULL
 );
 
+PRAGMA threads=CAST(@VAR('default_threads') AS INT64);
+
 SELECT
   owm.doi,
   MAX(publication_date) AS publication_date

--- a/queries/dmpworks/python/dmpworks/sql/models/openalex_index/title_stats.sql
+++ b/queries/dmpworks/python/dmpworks/sql/models/openalex_index/title_stats.sql
@@ -16,6 +16,8 @@ MODEL (
   kind FULL
 );
 
+PRAGMA threads=CAST(@VAR('default_threads') AS INT64);
+
 -- Choose the id with the longest title for each duplicate DOI
 SELECT
   COALESCE(ARG_MAX(owm.id, owm.title_length), MIN(id)) AS id,

--- a/queries/dmpworks/python/dmpworks/sql/models/openalex_index/titles.sql
+++ b/queries/dmpworks/python/dmpworks/sql/models/openalex_index/titles.sql
@@ -10,6 +10,8 @@ MODEL (
   kind FULL
 );
 
+PRAGMA threads=CAST(@VAR('openalex_index_titles_threads') AS INT64);
+
 SELECT
   stats.doi,
   CASE

--- a/queries/dmpworks/python/dmpworks/sql/models/openalex_index/types.sql
+++ b/queries/dmpworks/python/dmpworks/sql/models/openalex_index/types.sql
@@ -11,6 +11,8 @@ MODEL (
   kind FULL
 );
 
+PRAGMA threads=CAST(@VAR('default_threads') AS INT64);
+
 SELECT
   owm.doi,
   MODE(type ORDER BY type ASC) AS type,

--- a/queries/dmpworks/python/dmpworks/sql/models/openalex_index/updated_dates.sql
+++ b/queries/dmpworks/python/dmpworks/sql/models/openalex_index/updated_dates.sql
@@ -12,6 +12,8 @@ MODEL (
   kind FULL
 );
 
+PRAGMA threads=CAST(@VAR('default_threads') AS INT64);
+
 SELECT
   doi,
   MAX(updated_date) AS updated_date

--- a/queries/dmpworks/python/dmpworks/sql/models/openalex_index/works_metadata.sql
+++ b/queries/dmpworks/python/dmpworks/sql/models/openalex_index/works_metadata.sql
@@ -16,6 +16,10 @@ MODEL (
   kind FULL
 );
 
+PRAGMA threads=CAST(@VAR('default_threads') AS INT64);
+
+JINJA_QUERY_BEGIN;
+
 -- Remove works that can be found in DataCite
 WITH base AS (
   SELECT
@@ -37,8 +41,12 @@ SELECT
   base.id,
   base.doi,
   LENGTH(oaw.title) AS title_length,
+  {% if var('include_abstracts') %}
   LENGTH(oaw.abstract) AS abstract_length,
+  {% endif %}
   counts.doi_count > 1 AS is_duplicate
 FROM base
 LEFT JOIN counts ON base.doi = counts.doi
 LEFT JOIN openalex.works oaw ON base.id = oaw.id;
+
+JINJA_END;

--- a/queries/dmpworks/python/dmpworks/sql/models/ror/index.sql
+++ b/queries/dmpworks/python/dmpworks/sql/models/ror/index.sql
@@ -7,6 +7,8 @@ MODEL (
   )
 );
 
+PRAGMA threads=CAST(@VAR('default_threads') AS INT64);
+
 SELECT *
 FROM read_parquet(@VAR('ror_path') || '/ror.parquet');
 

--- a/queries/dmpworks/python/dmpworks/sql/models/works_index/exports.sql
+++ b/queries/dmpworks/python/dmpworks/sql/models/works_index/exports.sql
@@ -16,6 +16,8 @@ MODEL (
   depends_on (datacite_index.datacite_index, openalex_index.openalex_index) -- must manually specify these as they are not used within the query itself
 );
 
+PRAGMA threads=CAST(@VAR('default_threads') AS INT64);
+
 -- Record export date
 SELECT @end_ds AS export_date;
 


### PR DESCRIPTION
Enable a subset of SQLMesh queries to have their number of threads customised and bump up threads to 32, which reduces runtime from 243 minutes (2 threads) to 43 minutes (32 threads). 

The OpenAlex author names, abstracts, titles and openalex_index queries can be individually controlled as they use more memory and it is handy to be able to lower them whilst keeping the rest high when running locally.

I've also added a flag to exclude abstracts, which is also useful when running locally.