### PR TITLE
Refactor DMP data structure

### DIFF
--- a/queries/dmpworks/python/dmpworks/funders/parser.py
+++ b/queries/dmpworks/python/dmpworks/funders/parser.py
@@ -56,6 +56,10 @@ def fetch_funded_dois(
         awards = [award_id]
         awards.extend(award_id.related_awards)
         for award in awards:
+            if award.appl_id is None:
+                log.debug(f"Skipping fetching works for {canonical_id} as appl_id is None")
+                continue
+
             log.debug(f"Fetch works for {canonical_id} with appl_id={award.appl_id}")
             results = nih_fetch_award_publication_dois(
                 award.appl_id,

--- a/queries/dmpworks/python/dmpworks/model/dmp_model.py
+++ b/queries/dmpworks/python/dmpworks/model/dmp_model.py
@@ -23,38 +23,10 @@ class DMPModel(BaseModel):
     abstract: Optional[str]
     project_start: Optional[pendulum.Date]
     project_end: Optional[pendulum.Date]
-    affiliation_rors: list[str]
-    affiliation_names: list[str]
-    author_names: list[AuthorName]
-    author_orcids: list[str]
+    institutions: list[Institution]
+    authors: list[Author]
     funding: list[FundingItem]
     external_data: Optional[ExternalData] = None
-
-    @cached_property
-    def author_surnames(self) -> list[str]:
-        surnames = set()
-        for name in self.author_names:
-            if name.surname is not None:
-                surnames.add(name.surname)
-            else:
-                surnames.add(name.full)
-        return list(surnames)
-
-    @cached_property
-    def funder_ids(self) -> list[str]:
-        funder_ids = set()
-        for fund in self.funding:
-            if fund.funder.id is not None:
-                funder_ids.add(fund.funder.id)
-        return list(funder_ids)
-
-    @cached_property
-    def funder_names(self) -> list[str]:
-        funder_names = set()
-        for fund in self.funding:
-            if fund.funder.name is not None:
-                funder_names.add(fund.funder.name)
-        return list(funder_names)
 
     @cached_property
     def funded_dois(self) -> list[str]:
@@ -63,14 +35,6 @@ class DMPModel(BaseModel):
             for doi in award.funded_dois:
                 funded_dois.add(doi)
         return list(funded_dois)
-
-    @cached_property
-    def award_ids(self) -> list[str]:
-        award_ids = set()
-        for award in self.external_data.awards:
-            for award_id in award.award_id.all_variants:
-                award_ids.add(award_id)
-        return list(award_ids)
 
     @field_validator("created", "registered", "modified", "project_start", "project_end", mode="before")
     @classmethod
@@ -98,7 +62,13 @@ class FundingItem(BaseModel):
     award_id: Optional[str]
 
 
-class AuthorName(BaseModel):
+class Institution(BaseModel):
+    name: Optional[str]
+    ror: Optional[str]
+
+
+class Author(BaseModel):
+    orcid: Optional[str]
     first_initial: Optional[str]
     given_name: Optional[str]
     middle_initials: Optional[str]

--- a/queries/dmpworks/python/dmpworks/opensearch/cli.py
+++ b/queries/dmpworks/python/dmpworks/opensearch/cli.py
@@ -175,7 +175,7 @@ def enrich_dmps_cmd(
 def dmp_works_search_cmd(
     dmp_index_name: str,
     works_index_name: str,
-    out_dir: Annotated[
+    out_file: Annotated[
         pathlib.Path,
         Parameter(
             validator=validators.Path(
@@ -202,7 +202,7 @@ def dmp_works_search_cmd(
     Args:
         dmp_index_name: the name of the DMP index in OpenSearch.
         works_index_name: the name of the works index in OpenSearch.
-        out_dir: the output directory where search results will be saved.
+        out_file: the output directory where search results will be saved.
         scroll_time: the length of time the OpenSearch scroll used to iterate
         through DMPs will stay active. Set it to a value greater than the length
         of this process.
@@ -228,7 +228,7 @@ def dmp_works_search_cmd(
     dmp_works_search(
         dmp_index_name,
         works_index_name,
-        out_dir,
+        out_file,
         client_config,
         scroll_time=scroll_time,
         batch_size=batch_size,

--- a/queries/dmpworks/python/dmpworks/opensearch/dmp_works.py
+++ b/queries/dmpworks/python/dmpworks/opensearch/dmp_works.py
@@ -2,7 +2,7 @@ import dataclasses
 import json
 import logging
 import pathlib
-from typing import Callable
+from typing import Callable, Optional
 
 import jsonlines
 from opensearchpy import OpenSearch
@@ -196,7 +196,7 @@ def build_query(dmp: DMPModel, max_results: int, project_end_buffer_years: int) 
     should = []
 
     # Funded DOIs
-    if len(dmp.funded_dois):
+    if dmp.funded_dois:
         should.append(
             {
                 "constant_score": {
@@ -246,18 +246,20 @@ def build_query(dmp: DMPModel, max_results: int, project_end_buffer_years: int) 
 
     # Authors
     # Combines author_orcids and author surnames into a single feature
-    build_entity_query(
+    authors = build_entity_query(
         "authors",
         "author_orcids",
         "author_names",
         dmp.authors,
-        lambda author: author.ror,
+        lambda author: author.orcid,
         lambda author: author.surname,
     )
+    if authors is not None:
+        should.append(authors)
 
     # Institutions
     # Combines both affiliation_rors and affiliation_names into a single feature
-    build_entity_query(
+    institutions = build_entity_query(
         "institutions",
         "affiliation_rors",
         "affiliation_names",
@@ -265,10 +267,12 @@ def build_query(dmp: DMPModel, max_results: int, project_end_buffer_years: int) 
         lambda inst: inst.ror,
         lambda inst: inst.name,
     )
+    if institutions is not None:
+        should.append(institutions)
 
     # Funders
     # Combines both funder_ids and funder_names into a single feature
-    build_entity_query(
+    funders = build_entity_query(
         "funders",
         "funder_ids",
         "funder_names",
@@ -276,52 +280,64 @@ def build_query(dmp: DMPModel, max_results: int, project_end_buffer_years: int) 
         lambda fund: fund.funder.id,
         lambda fund: fund.funder.name,
     )
+    if funders is not None:
+        should.append(funders)
 
     # Title and abstract
+    has_text = dmp.title is not None or dmp.abstract is not None
     content: str = " ".join([text for text in [dmp.title, dmp.abstract] if text is not None and text != ""])
-    should.append(
-        {
-            "more_like_this": {
-                "_name": name_group("content"),
-                "fields": ["title", "abstract"],
-                "like": content,
-                "min_term_freq": 1,
+    if has_text:
+        should.append(
+            {
+                "more_like_this": {
+                    "_name": name_group("content"),
+                    "fields": ["title", "abstract"],
+                    "like": content,
+                    "min_term_freq": 1,
+                }
             }
-        }
-    )
+        )
 
     # Final query and filter based on date range
     # also remove DMPs from search results (output-management-plan type)
-    gte = dmp.project_start.format("YYYY-MM-DD")
-    lte = dmp.project_end.add(years=project_end_buffer_years).format("YYYY-MM-DD")
+    filters = [
+        {
+            "bool": {
+                "must_not": {
+                    "term": {
+                        "type": "output-management-plan",
+                    }
+                }
+            },
+        }
+    ]
+    if dmp.project_start is not None:
+        gte = dmp.project_start.format("YYYY-MM-DD")
+        lte = dmp.project_end.add(years=project_end_buffer_years).format("YYYY-MM-DD")
+        filters.append(
+            {
+                "range": {
+                    "publication_date": {
+                        "gte": gte,
+                        "lte": lte,
+                    },
+                }
+            }
+        )
+
     query = {
         "size": max_results,
         "query": {
             "bool": {
                 "should": should,
-                "filter": [
-                    {
-                        "range": {
-                            "publication_date": {
-                                "gte": gte,
-                                "lte": lte,
-                            },
-                        }
-                    },
-                    {
-                        "bool": {
-                            "must_not": {
-                                "term": {
-                                    "type": "output-management-plan",
-                                }
-                            }
-                        },
-                    },
-                ],
+                "filter": filters,
                 "minimum_should_match": 1,
             },
         },
-        "highlight": {
+    }
+
+    if has_text:
+        query["highlight"] = {
             "pre_tags": ["<mark>"],
             "post_tags": ["</mark>"],
             "order": "score",
@@ -345,8 +361,7 @@ def build_query(dmp: DMPModel, max_results: int, project_end_buffer_years: int) 
                     "min_term_freq": 1,
                 }
             },
-        },
-    }
+        }
 
     return query
 
@@ -358,39 +373,54 @@ def build_entity_query(
     items: list,
     id_accessor: Callable,
     name_accessor: Callable,
-) -> dict:
-    return {
-        "bool": {
-            "_name": name_group(group_name),
-            "minimum_should_match": 1,
-            "should": [
-                *[
-                    {
-                        "dis_max": {
-                            "_name": name_entity(group_name, idx),
-                            "tie_breaker": 0,
-                            "queries": [
-                                {
-                                    "constant_score": {
-                                        "_name": name_value(group_name, idx, "id", id_accessor(item)),
-                                        "filter": {"term": {id_field: id_accessor(item)}},
-                                        "boost": 2,
-                                    }
-                                },
-                                {
-                                    "constant_score": {
-                                        "_name": name_value(group_name, idx, "name", name_accessor(item)),
-                                        "filter": {
-                                            "match_phrase": {name_field: {"query": name_accessor(item), "slop": 3}}
-                                        },
-                                        "boost": 1,
-                                    }
-                                },
-                            ],
-                        },
+) -> Optional[dict]:
+    should_queries = []
+
+    for idx, item in enumerate(items):
+        entity_queries = []
+        entity_id = id_accessor(item)
+        entity_name = name_accessor(item)
+
+        if entity_id is not None:
+            entity_queries.append(
+                {
+                    "constant_score": {
+                        "_name": name_value(group_name, idx, "id", entity_id),
+                        "filter": {"term": {id_field: entity_id}},
+                        "boost": 2,
                     }
-                    for idx, item in enumerate(items)
-                ]
-            ],
+                }
+            )
+
+        if entity_name is not None:
+            entity_queries.append(
+                {
+                    "constant_score": {
+                        "_name": name_value(group_name, idx, "name", entity_name),
+                        "filter": {"match_phrase": {name_field: {"query": entity_name, "slop": 3}}},
+                        "boost": 1,
+                    }
+                }
+            )
+
+        if entity_queries:
+            should_queries.append(
+                {
+                    "dis_max": {
+                        "_name": name_entity(group_name, idx),
+                        "tie_breaker": 0,
+                        "queries": entity_queries,
+                    },
+                }
+            )
+
+    if should_queries:
+        return {
+            "bool": {
+                "_name": name_group(group_name),
+                "minimum_should_match": 1,
+                "should": should_queries,
+            }
         }
-    }
+
+    return None

--- a/queries/dmpworks/python/dmpworks/opensearch/mappings/dmps-mapping.json
+++ b/queries/dmpworks/python/dmpworks/opensearch/mappings/dmps-mapping.json
@@ -61,27 +61,32 @@
       "project_end": {
         "type": "date"
       },
-      "affiliation_rors": {
-        "type": "keyword",
-        "normalizer": "lowercase"
-      },
-      "affiliation_names": {
-        "type": "text",
-        "analyzer": "icu_analyzer",
-        "fields": {
-          "keyword": {
+      "institutions": {
+        "type": "nested",
+        "properties": {
+          "ror": {
             "type": "keyword",
-            "normalizer": "name_normalizer"
+            "normalizer": "lowercase"
+          },
+          "name": {
+            "type": "text",
+            "analyzer": "icu_analyzer",
+            "fields": {
+              "keyword": {
+                "type": "keyword",
+                "normalizer": "name_normalizer"
+              }
+            }
           }
         }
       },
-      "author_orcids": {
-        "type": "keyword",
-        "normalizer": "lowercase"
-      },
-      "author_names": {
+      "authors": {
         "type": "nested",
         "properties": {
+          "orcid": {
+            "type": "keyword",
+            "normalizer": "lowercase"
+          },
           "first_initial": {
             "type": "text",
             "analyzer": "icu_analyzer",

--- a/queries/dmpworks/python/dmpworks/opensearch/sync_dmps.py
+++ b/queries/dmpworks/python/dmpworks/opensearch/sync_dmps.py
@@ -19,10 +19,8 @@ COLUMNS = [
     "abstract",
     "project_start",
     "project_end",
-    "affiliation_rors",
-    "affiliation_names",
-    "author_names",
-    "author_orcids",
+    "institutions",
+    "authors",
     "funding",
 ]
 

--- a/queries/dmpworks/python/dmpworks/transform/dmps.py
+++ b/queries/dmpworks/python/dmpworks/transform/dmps.py
@@ -60,10 +60,22 @@ SCHEMA: SchemaDefinition = {
     "description": pl.String,
     "project_start": pl.Date,
     "project_end": pl.Date,
-    "affiliation_ids": pl.List(pl.String),
-    "affiliations": pl.List(pl.String),
-    "people": pl.List(pl.String),
-    "people_ids": pl.List(pl.String),
+    "institutions": pl.List(
+        pl.Struct(
+            {
+                "name": pl.String,
+                "ror": pl.String,
+            }
+        )
+    ),
+    "authors": pl.List(
+        pl.Struct(
+            {
+                "name": pl.String,
+                "orcid": pl.String,
+            }
+        )
+    ),
     "funding": pl.List(
         pl.Struct(
             {
@@ -119,21 +131,51 @@ def transform(lz: pl.LazyFrame) -> list[tuple[str, pl.LazyFrame]]:
         abstract=clean_string(pe.strip_markup(pl.col("description"))),
         project_start=pl.col("project_start"),
         project_end=pl.col("project_end"),
-        affiliation_rors=pl.col("affiliation_ids").list.eval(clean_string(pl.element())).list.drop_nulls(),
-        affiliation_names=pl.col("affiliations").list.eval(clean_string(pl.element())).list.drop_nulls(),
-        # people: remove emails, remove empty strings, split into name parts
-        author_names=pl.col("people")
-        .list.eval(clean_name(pl.element()))
-        .list.drop_nulls()
-        .list.eval(pe.parse_name(pl.element())),
-        # people_ids: extract ORCID IDs, which also removes emails
-        author_orcids=pl.col("people_ids").list.eval(extract_orcid(pl.element())).list.drop_nulls(),
+        # institutions: strip name and ror
+        institutions=pl.col("institutions")
+        .list.eval(
+            pl.struct(
+                ror=clean_string(pl.element().struct.field("ror")),
+                name=clean_string(pl.element().struct.field("name")),
+            )
+        )
+        .filter(pl.any_horizontal([pl.element().struct.field(field).is_not_null() for field in ["name", "ror"]]))
+        .list.drop_nulls(),
+        # authors: remove empty strings, split into name parts, extract ORCID IDs
+        authors=pl.col("authors")
+        .list.eval(
+            pl.struct(
+                [
+                    extract_orcid(pl.element().struct.field("orcid")).alias("orcid"),
+                    pe.parse_name(pl.element().struct.field("name")).struct.unnest(),
+                ]
+            )
+        )
+        .filter(
+            pl.any_horizontal(
+                [
+                    pl.element().struct.field(field).is_not_null()
+                    for field in [
+                        "orcid",
+                        "first_initial",
+                        "given_name",
+                        "middle_initials",
+                        "middle_names",
+                        "surname",
+                        "full",
+                    ]
+                ]
+            )
+        )
+        .list.drop_nulls(),
         # funding: remove values that are likely not award IDs, e.g. empty strings, na, n/a etc
         funding=pl.col("funding")
         .list.eval(
             pl.struct(
                 funder=pl.struct(
-                    id=clean_string(pl.element().struct.field("funder").struct.field("id")),
+                    id=clean_string(
+                        pl.element().struct.field("funder").struct.field("id")
+                    ),  # TODO: check if these also include Crossref IDs
                     name=clean_string(
                         pl.element().struct.field("funder").struct.field("name"),
                     ),
@@ -149,8 +191,17 @@ def transform(lz: pl.LazyFrame) -> list[tuple[str, pl.LazyFrame]]:
                 ),
             )
         )
+        .filter(
+            pl.any_horizontal(
+                [pl.element().struct.field("funder").struct.field(field).is_not_null() for field in ["id", "name"]]
+                + [
+                    pl.element().struct.field(field).is_not_null()
+                    for field in ["funder", "status", "funding_opportunity_id", "award_id"]
+                ]
+            )
+        )
         .list.drop_nulls(),
-    ).filter(
+    ).filter(  # TODO: remove these filters
         pl.col("funding")
         .list.eval(
             pl.element().struct.field("funder").struct.field("id").is_in(["01cwqze88", "021nxhr62", "05wqqhv83"])


### PR DESCRIPTION
This PR refactors the DMP data structure to return authors and institutions as lists of objects and adjusts the DMP search to work with this format.

It has been tested on the real data.